### PR TITLE
Also bump the Gemfile.lock (if present) versions number

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,5 +70,13 @@ fi
 setup_git
 setup_gem_credentials
 setup_env
-gem bump --commit --version ${BUMP_LEVEL} --push --tag --release
 
+gem bump --commit --version ${BUMP_LEVEL}
+if [ -f Gemfile.lock ]; then
+  bundle install
+  git add Gemfile.lock
+  git commit --amend --no-edit
+fi
+git push origin
+gem tag --push
+gem release


### PR DESCRIPTION
Extracted the commands into multiple commands

@InteNs no sure how we want to test this. I could point the workflow to this branch, but it will still push the gem to gem server

[DEV-2413](https://jobport.atlassian.net/browse/DEV-2413)

[DEV-2413]: https://jobport.atlassian.net/browse/DEV-2413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ