### PR TITLE
Bump ruby (mainly for bundler)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM ruby:2.7.1-alpine3.11 as base
-RUN apk --no-cache add git jq curl
+FROM ruby:3.2.1-alpine3.17 as base
+RUN gem update --system 3.4.7 && \
+    apk --no-cache add git jq curl
 RUN gem install gem-release
 COPY labels /labels
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,14 +52,14 @@ elif echo "${LABELS}" | grep "bump:minor" ; then
 elif echo "${LABELS}" | grep "bump:patch" ; then
   BUMP_LEVEL="patch"
 fi
-echo "::set-output name=level::#{BUMP_LEVEL}"
+echo "level=#{BUMP_LEVEL}" >> $GITHUB_OUTPUT
 
 if [ -z "${BUMP_LEVEL}" ]; then
   echo "PR with labels for bump not found. Do nothing."
-  echo "::set-output name=skipped::true"
+  echo "skipped=true" >> $GITHUB_OUTPUT
   exit
 else
-  echo "::set-output name=skipped::false"
+  echo "skipped=false" >> $GITHUB_OUTPUT
 fi
 
 echo "Bump ${BUMP_LEVEL} version"


### PR DESCRIPTION
Also fixing the deprecation of `::set-output`

## Main reason

I've had the issue where the default bundler version of this base ruby image was 2.1.4, but the Gemfile.lock required a different version. This resulted in exit and no release 👎 
Since version 2.3 of bundler it will install the required bundler version and use that, which would resolve my issue

ref: https://bundler.io/blog/2022/01/23/bundler-v2-3.html