### PR TITLE
Document permissions + small maintainance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.1-alpine3.17 as base
+FROM ruby:3.2.1-alpine3.17 AS base
 RUN gem update --system 3.4.7 && \
     apk --no-cache add git jq curl
 RUN gem install gem-release

--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ Always true when DRY_RUN=true.
 
 `major`/`minor`/`patch`
 The bump level that was used.
+
+
+## Permissions Required
+
+This action requires the following permissions:
+
+```yaml
+permissions:
+  pull-requests: read
+  contents: write
+```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This action requires the following permissions:
 
 ```yaml
 permissions:
+  issues: write  # For creating labels
   pull-requests: read
   contents: write
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "bump gem - Bump gem version when merging Pull Request with bump labels"
-description: "Bump gem version when merging Pull Request with specific labels (bump:major,bump:minor,bump:patch)"
+description: "Bump gem version when merging Pull Request with specific labels (bump:major,bump:minor,bump:patch). Automatically creates required labels if they don't exist."
 author: "tijn,intens"
 inputs:
   default_bump_level:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,28 @@ cd "${GITHUB_WORKSPACE}" || exit 1
 
 git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+
+# Create labels if they don't exist
+create_labels() {
+  echo "Setting up bump labels..."
+
+  for label_file in /labels/*.json; do
+    if [ -f "$label_file" ]; then
+      label_name=$(jq -r '.name' "$label_file")
+      label_color=$(jq -r '.color' "$label_file")
+      label_desc=$(jq -r '.description' "$label_file")
+
+      echo "Creating label: ${label_name}"
+      curl -s -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/labels" \
+        -d "{\"name\":\"${label_name}\",\"color\":\"${label_color}\",\"description\":\"${label_desc}\"}"
+    fi
+  done
+}
+
 # Setup these env variables.
 # - LABELS
 # - PR_NUMBER
@@ -50,6 +72,7 @@ setup_env() {
   export GEM_RELEASE_RELEASE_GITHUB=true
 }
 
+create_labels
 setup_from_push_event
 
 BUMP_LEVEL="${INPUT_DEFAULT_BUMP_LEVEL}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,11 @@ setup_from_push_event() {
 list_pulls() {
   pulls_endpoint="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=closed&sort=updated&direction=desc"
   if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
-    curl -s -H "Authorization: token ${INPUT_GITHUB_TOKEN}" "${pulls_endpoint}"
+    curl -s \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "${pulls_endpoint}"
   else
     echo "INPUT_GITHUB_TOKEN is not available. Subscequent GitHub API call may fail due to API limit." >&2
     curl -s "${pulls_endpoint}"


### PR DESCRIPTION
    1. Use headers that GitHub docs list in their example
       See: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests

    2. Document required permissions

    3. Use consistent casing in Dockerfile; this removes a warning from the
       output; which results in a bit less clutter.

    4. Create label definitions if they don't exist yet. This won't update the labels if we ever change them but I think that's okay since we don't expect them to change soon.